### PR TITLE
Accept brackets around {disabled: quantity === 0}

### DIFF
--- a/src/lib/challenges/challenge-3/steps.ts
+++ b/src/lib/challenges/challenge-3/steps.ts
@@ -12,7 +12,7 @@ const containsAccessibilityState = (code: string) => {
 
   const minusButton = allButtons[0];
   return !!minusButton?.match(
-    /accessibilityState={\s*{\s*disabled:\s*quantity\s*===\s*0\s*}\s*}/gm
+    /accessibilityState\s*=\s*{\s*\(?\s*{\s*disabled:\s*\(?\s*quantity\s*===\s*0\s*\)?\s*}\s*\)?\s*}/gm
   );
 };
 


### PR DESCRIPTION
It will now accept `accessibilityState={({disabled: quantity === 0})}`, with the brackets between the two `{{`. It won't accept addition of brackets anywhere else as if they are added elsewhere it triggers an error in Expo.