### PR TITLE
Add disabled button styling for C3

### DIFF
--- a/src/lib/challenges/challenge-3/initialCode.ts
+++ b/src/lib/challenges/challenge-3/initialCode.ts
@@ -42,7 +42,7 @@ const RecordSummary = ({record}: RecordSummaryProperties) => {
         <Text style={styles.recordArtist}>{record.artist}</Text>
       </View>
       <View style={styles.quantityCounter}>
-        <TouchableOpacity style={styles.quantityButton}
+        <TouchableOpacity style={[styles.quantityButton, quantity === 0 && styles.disabledButton]}
                           onPress={() => setQuantity(quantity - 1)}
                           disabled={quantity === 0}
                           role="button"
@@ -164,6 +164,9 @@ quantityCounter: {
 quantityButton: {
   padding: 0,
   margin: 0
+},
+disabledButton: {
+  opacity: 0.5
 },
 quantity: {
   fontWeight: 'bold',


### PR DESCRIPTION
Greys out the minus button when it is disabled by setting opacity to 50%. Added as an additional styling rather than an alternate styling to an "enabled" quantity button so that it doesn't change the padding/margin challenge as this styling will still apply to both enabled and disabled buttons.