### PR TITLE
Update landing page with link to Expo Go and additional info

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,10 +55,8 @@ export default function Home() {
             What do you need to get started
           </h2>
           <ul className="list-disc ml-5 mt-5 mb-10">
-            <li>A phone with{' '}
-              <a href="https://expo.dev/go">
-                Expo Go
-              </a>{' '}
+            <li>A phone with
+              <a href="https://expo.dev/go"> Expo Go </a>
               installed
             </li>
             <li>


### PR DESCRIPTION
Updates landing page with:
- link to Expo Go
- highlights that the IDE doesn't tell you about errors, but Expo does
- prompt to quit Expo and restart if having Expo issues