### PR TITLE
Fix hint overflow

### DIFF
--- a/src/app/challenges/[id]/EditorTools.tsx
+++ b/src/app/challenges/[id]/EditorTools.tsx
@@ -51,8 +51,8 @@ export default function EditorTools({
 
   return (
     <>
-      <div className=" w-full flex flex-row mt-10 justify-between min-h-60">
-        <div className="w-8/12 flex flex-col justify-items-start min-h-60">
+      <div className="w-full flex flex-row mt-10 justify-between min-h-60 space-x-5">
+        <div className="w-2/3 flex flex-col justify-items-start min-h-60">
           <div className="mb-5">
             <h3 className="text-lg">Editor tools</h3>
           </div>
@@ -66,7 +66,7 @@ export default function EditorTools({
               onClick={runTests}
             />
           </div>
-          <HintBox challenge={challenge}/>
+          <HintBox challenge={challenge} />
           <div className="mt-5">
             {showTests &&
               testResults.map((step, index) => {
@@ -87,13 +87,15 @@ export default function EditorTools({
               })}
           </div>
         </div>
-        <SnackLink isOnline={snackState.online} link={snackState.url} />
-      </div>
-      {showChallengeCompleted && (
-        <div className="w-full mt-5">
-          <ChallengeCompleted challenge={challenge} />
+        <div className="max-w-1/3 flex flex-col items-end">
+          <SnackLink isOnline={snackState.online} link={snackState.url} />
         </div>
-      )}
-    </>
-  );
-}
+        </div>
+        {showChallengeCompleted && (
+          <div className="w-full mt-5">
+            <ChallengeCompleted challenge={challenge} />
+          </div>
+        )}
+      </>
+      );
+      }

--- a/src/app/challenges/[id]/HintBox.tsx
+++ b/src/app/challenges/[id]/HintBox.tsx
@@ -29,7 +29,7 @@ export default function HintBox({ challenge }: { challenge: Challenge }) {
   }, [challenge]);
 
   return (
-    <div className="flex flex-row items-center rounded border border-teal-900 p-3 mt-5 space-x-3">
+    <div className="flex flex-row items-center rounded border border-teal-900 p-3 mt-5 space-x-3 overflow-x-auto">
       {hintIndex !== undefined && hintIndex > 0 && (
         <Button
           label={'<'}

--- a/src/app/challenges/[id]/HintBox.tsx
+++ b/src/app/challenges/[id]/HintBox.tsx
@@ -13,9 +13,10 @@ const renderHint = (hints: Hint[], hintIndex: number) => {
 
   return (
     <>
-      <p>
+      <p className="break-words">
         {hint.message}
-        {hint.link && <a href={hint.link}> {hint.link}</a>}
+        <br/>
+        {hint.link && <a href={hint.link} className="break-all"> {hint.link}</a>}
       </p>
     </>
   );
@@ -28,7 +29,7 @@ export default function HintBox({ challenge }: { challenge: Challenge }) {
   }, [challenge]);
 
   return (
-    <div className="flex flex-row rounded border border-teal-900 p-3 mt-5 grid-cols-3">
+    <div className="flex flex-row items-center rounded border border-teal-900 p-3 mt-5 space-x-3">
       {hintIndex !== undefined && hintIndex > 0 && (
         <Button
           label={'<'}

--- a/src/app/challenges/[id]/SnackLink.tsx
+++ b/src/app/challenges/[id]/SnackLink.tsx
@@ -8,7 +8,7 @@ export type SnackLinkProps = {
 
 export default function SnackLink({ isOnline, link }: SnackLinkProps) {
   return (
-    <div className="w-4/12 flex flex-col justify-items-end  min-h-60">
+    <div className="w-full flex flex-col justify-items-end min-h-60">
       <div className="mb-5 text-right">
         <h3 className="text-lg"> Run it on your phone</h3>
       </div>


### PR DESCRIPTION
I've prevented the hintBox and QR code from overlapping by setting the max with of each to 1/3 (QR code) and 2/3 (hint box).

Also I've made the hint box horizontally scrollable if the content overlaps. It should wrap the text as much as possible but once there is a word which is on its own line and still too long it will clip to the boundary of the hint box and make it scrollable to read content. (screenshots attached!) 

![Screenshot 2024-09-30 at 17 44 12](https://github.com/user-attachments/assets/d7ac98da-2422-4569-a4e1-1e6232610a2c)

![Screenshot 2024-09-30 at 17 45 17](https://github.com/user-attachments/assets/1aeee84a-dedf-4cc9-91f3-7af0afedca11)

![Screenshot 2024-09-30 at 17 45 43](https://github.com/user-attachments/assets/48a00617-98f4-4250-9e34-cc8d4e8c8003)



